### PR TITLE
make output-only tasks compatible with tps

### DIFF
--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -51,7 +51,7 @@ class OutputOnly(TaskType):
     CHECKER_CODENAME = "checker"
     # Template for the filename of the output files provided by the user; %s
     # represent the testcase codename.
-    USER_OUTPUT_FILENAME_TEMPLATE = "output_%s.txt"
+    USER_OUTPUT_FILENAME_TEMPLATE = "%s.out"
 
     # Constants used in the parameter definition.
     OUTPUT_EVAL_DIFF = "diff"


### PR DESCRIPTION
change the output filenames of OutputOnly tasks to be compatible with the tps-exported tasks.